### PR TITLE
chore: Update Dockerfiles to golang 1.22 and remove deprecated port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 AS build
+FROM golang:1.22 AS build
 ARG BEE_REPO='https://github.com/Solar-Punk-Ltd/bee.git'
 ARG BEE_BRANCH=act
 
@@ -26,7 +26,7 @@ RUN mkdir -p /home/bee/.bee && chown 999:999 /home/bee/.bee
 
 COPY --from=build /repo/bee/dist/bee /usr/local/bin/bee
 
-EXPOSE 1633 1634 1635
+EXPOSE 1633 1634
 USER bee
 WORKDIR /home/bee
 VOLUME /home/bee/.bee

--- a/sepolia.Dockerfile
+++ b/sepolia.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 AS build
+FROM golang:1.22 AS build
 ARG BEE_REPO='https://github.com/Solar-Punk-Ltd/bee.git'
 ARG BEE_BRANCH=act
 
@@ -40,7 +40,7 @@ COPY **/test_suite.sh /home/bee/test_suite.sh
 COPY **/updown.hurl /home/bee/updown.hurl
 COPY **/bee-sepolia.yaml /home/bee/bee.yaml
 
-EXPOSE 1633 1634 1635
+EXPOSE 1633 1634
 USER bee
 WORKDIR /home/bee
 

--- a/sepolia/run_sepolia.sh
+++ b/sepolia/run_sepolia.sh
@@ -20,7 +20,7 @@ printf "Building image %s ...\n" "$docker_image"
 docker build -q -t "$docker_image" -f ../sepolia.Dockerfile .
 
 printf "Starting container as %s ...\n" "$docker_container"
-docker run -d -p 1633:1633 -p 1634:1634 -p 1635:1635 --name "$docker_container" "$docker_image"
+docker run -d -p 1633:1633 -p 1634:1634 --name "$docker_container" "$docker_image"
 
 sleep 4
 node_wallet=$(docker logs sp-bee-sepolia | grep 'cannot continue until there is at least' | grep -o -E 'address"="0x[a-fA-F0-9]{40}' | uniq | awk -F'="' '{print $2}')

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 AS build
+FROM golang:1.22 AS build
 ARG BEE_REPO='https://github.com/Solar-Punk-Ltd/bee.git'
 ARG BEE_BRANCH=act
 
@@ -39,7 +39,7 @@ COPY test.sh /home/bee/test.sh
 COPY test_suite.sh /home/bee/test_suite.sh
 COPY updown.hurl /home/bee/updown.hurl
 
-EXPOSE 1633 1634 1635
+EXPOSE 1633 1634
 USER bee
 WORKDIR /home/bee
 

--- a/updown.hurl
+++ b/updown.hurl
@@ -1,16 +1,15 @@
 # public key
-GET http://{{host}}:{{bee_debug_api_port}}/addresses
+GET http://{{host}}:{{bee_api_port}}/addresses
 Accept: */*
 [Options]
 variable: host=localhost
 variable: bee_api_port=1633
-variable: bee_debug_api_port=1635
 HTTP 200
 [Captures]
 public_key: jsonpath "$.publicKey"
 
 # stamp
-POST http://{{host}}:{{bee_debug_api_port}}/stamps/420000000/17
+POST http://{{host}}:{{bee_api_port}}/stamps/420000000/17
 Accept: */*
 HTTP 201
 [Captures]

--- a/updown.sh
+++ b/updown.sh
@@ -3,7 +3,6 @@
 input_file=$1
 host="localhost"
 bee_api_port="1633"
-bee_debug_port="1635"
 
 cleanup() {
     # before exit, remove the downloaded file
@@ -16,14 +15,14 @@ trap cleanup EXIT
 # ----------------
 # public key
 # ----------------
-addresses_response=$(curl -s "http://${host}:${bee_debug_port}/addresses" \
+addresses_response=$(curl -s "http://${host}:${bee_api_port}/addresses" \
     -H "accept: application/json, text/plain, */*")
 public_key=$(echo "$addresses_response" | jq -r '.publicKey')
 
 # ----------------
 # stamp
 # ----------------
-stamp_url="http://${host}:${bee_debug_port}/stamps/420000000/17"
+stamp_url="http://${host}:${bee_api_port}/stamps/420000000/17"
 echo "Buying stamp        POST: ${stamp_url}"
 stamp_response=$(curl -s -X POST "${stamp_url}" -H "accept: application/json, text/plain, */*")
 stamp_batch_id=$(echo "$stamp_response" | jq -r '.batchID')


### PR DESCRIPTION
- Upgrade golang version from 1.21 to 1.22 in Dockerfiles
- Remove usage of deprecated debug port to align with new bee API changes